### PR TITLE
Update TaskSketcherTool.cpp

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherTool.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherTool.cpp
@@ -39,6 +39,7 @@
 #include <Base/UnitsApi.h>
 
 #include <QEvent>
+#include <QMdiSubWindow>
 
 #include "ViewProviderSketch.h"
 


### PR DESCRIPTION
Fix compile error `TaskSketcherTool.cpp:223:27: error: invalid use of incomplete type ‘class QMdiSubWindow’`