### PR TITLE
Update FreeCAD Dark.qss

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -104,8 +104,7 @@ Main window
 ==================================================================================================*/
 QMainWindow,
 QDialog,
-QDockWidget,
-QToolBar  {
+QDockWidget {
     background-color: #333333; /* main background color */
 }
 
@@ -881,7 +880,7 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbar
 
 --------------------------------------------------------------------------- */
 QToolBar {
-  background-color: #333333;
+  /* background-color: #333333; */
   /* border: 1px solid #020202; */
   /* font-weight: bold; */
 }


### PR DESCRIPTION
In dark mode,
When you put a toolbar in the menubar (corner widget), then the background is of the toolbar is light gray and not dark gray like the menu bar.