### PR TITLE
Fix https://github.com/FreeCAD/FreeCAD/issues/21936

### DIFF
--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -1242,9 +1242,6 @@ TaskDlgAttacher::~TaskDlgAttacher()
     if (accepted && onAccept) {
         onAccept();
     }
-    else if (onReject) {
-        onReject();
-    }
 };
 
 //==== calls from the TaskView ===============================================================
@@ -1307,6 +1304,10 @@ bool TaskDlgAttacher::accept()
 
 bool TaskDlgAttacher::reject()
 {
+    if (onReject) {
+        onReject();
+    }
+    
     Gui::DocumentT doc(getDocumentName());
     Gui::Document* document = doc.getDocument();
     if (document) {


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/21936

The issue was that onReject was capturing a pointer to the new body. But the abortCommand was already removing the body. So onReject should not be called in the dtor but before abortCommand in reject.